### PR TITLE
Padding no body gera um scrollbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,9 @@ body {
   font: 14px "Verdana", Helvetica, Arial, sans-serif;
   background: #444;
   color: #FFF;
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 #tabuleiro {


### PR DESCRIPTION
O padding no body gera um scrollbar, o "box-sizing: border-box;" faz o padding ser "calculado" junto a altura, assim o body não vai ficar maior que o tamanho pré-definido e ainda terá os espaçamentos